### PR TITLE
Allow MediaExtension to be extended

### DIFF
--- a/Twig/Extension/MediaExtension.php
+++ b/Twig/Extension/MediaExtension.php
@@ -56,9 +56,9 @@ class MediaExtension extends \Twig_Extension implements \Twig_Extension_InitRunt
     public function getTokenParsers()
     {
         return array(
-            new MediaTokenParser(get_class()),
-            new ThumbnailTokenParser(get_class()),
-            new PathTokenParser(get_class()),
+            new MediaTokenParser(get_called_class()),
+            new ThumbnailTokenParser(get_called_class()),
+            new PathTokenParser(get_called_class()),
         );
     }
 


### PR DESCRIPTION
Change get_class() to get_called_class() to support extending the MediaExtension

I am targeting this branch, because I am trying to extend the MediaExtension twig extension to add my own custom twig methods.

Closes #1238

## Changelog

```markdown


### Changed
getTokenParsers() method by replacing get_class() to get_called_class()

### Fixed
Ability to extend the MediaExtension class

```
